### PR TITLE
Defensive fix: handle HTTP 412 PreconditionFailed on dataset access update in kds-team.app-bigquery-byodb-view-writer

### DIFF
--- a/src/google_cloud/bigquery_client.py
+++ b/src/google_cloud/bigquery_client.py
@@ -79,6 +79,7 @@ class BigqueryClient:
                 )
                 time.sleep(delay)
                 delay = min(delay * 2, 30)
+                self.client.project = source_dataset.project
                 source_dataset = self.client.get_dataset(
                     f"{source_dataset.project}.{source_dataset.dataset_id}"
                 )

--- a/src/google_cloud/bigquery_client.py
+++ b/src/google_cloud/bigquery_client.py
@@ -1,8 +1,9 @@
 import logging
+import time
 
 from google.cloud import bigquery
 from google.oauth2 import service_account
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import NotFound, PreconditionFailed
 
 
 class BigqueryClient:
@@ -15,8 +16,8 @@ class BigqueryClient:
     def __init__(self, credentials):
         self.client = bigquery.Client(credentials=credentials)
 
-    def _update_access(self, source_dataset, view):
-        access_entries = source_dataset.access_entries
+    def _grant_view_access(self, dataset, view):
+        access_entries = dataset.access_entries
         logging.info(f"Access entries before update: {access_entries}")
 
         new_access_entry = bigquery.AccessEntry(
@@ -37,7 +38,7 @@ class BigqueryClient:
             for entry in access_entries
         ):
             access_entries.append(new_access_entry)
-            source_dataset.access_entries = access_entries
+            dataset.access_entries = access_entries
             logging.info(
                 f"View {view.reference} has been granted access to the source dataset"
             )
@@ -46,11 +47,41 @@ class BigqueryClient:
                 f"View {view.reference} already has access to the source dataset"
             )
 
-        self.client.project = source_dataset.project
-        self.client.update_dataset(source_dataset, ["access_entries"])
+        self.client.project = dataset.project
+        self.client.update_dataset(dataset, ["access_entries"])
         logging.info(
-            f"Access entries have been updated: {source_dataset.access_entries}"
+            f"Access entries have been updated: {dataset.access_entries}"
         )
+
+    def _update_access(self, source_dataset, view):
+        # ``update_dataset`` sends the dataset's ETag as an ``If-Match`` header, so a
+        # concurrent change to the source dataset's access entries (e.g. another view
+        # writer granting access at the same time) makes it fail with HTTP 412
+        # PreconditionFailed. Retry with a freshly fetched dataset (and thus a fresh
+        # ETag), re-merging the view access entry so any concurrent additions are kept.
+        # A persistent conflict still fails loudly after the last attempt.
+        attempts = 5
+        delay = 2
+        for attempt in range(1, attempts + 1):
+            try:
+                self._grant_view_access(source_dataset, view)
+                return
+            except PreconditionFailed as exc:
+                if attempt == attempts:
+                    raise
+                logging.warning(
+                    "Source dataset access entries changed concurrently "
+                    "(HTTP 412: %s), retry %d/%d in %ds; re-fetching the dataset.",
+                    exc,
+                    attempt,
+                    attempts,
+                    delay,
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, 30)
+                source_dataset = self.client.get_dataset(
+                    f"{source_dataset.project}.{source_dataset.dataset_id}"
+                )
 
     def find_dataset(self, project_id, dataset_id):
         dataset_id_full = f"{project_id}.{dataset_id}"

--- a/tests/test_bigquery_client.py
+++ b/tests/test_bigquery_client.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for the defensive retry added to
+``BigqueryClient._update_access`` — it must retry on an HTTP 412
+``PreconditionFailed`` (concurrent modification of the source dataset access
+entries) with a freshly fetched dataset, and re-raise after the last attempt.
+"""
+
+import unittest
+import mock
+
+from google.api_core.exceptions import PreconditionFailed
+
+from google_cloud.bigquery_client import BigqueryClient
+
+
+def _make_view():
+    view = mock.MagicMock()
+    view.reference.project = "view-project"
+    view.reference.dataset_id = "view_dataset"
+    view.reference.table_id = "view_table"
+    return view
+
+
+def _make_dataset(access_entries=None):
+    dataset = mock.MagicMock()
+    dataset.project = "src-project"
+    dataset.dataset_id = "src_dataset"
+    dataset.access_entries = list(access_entries) if access_entries else []
+    return dataset
+
+
+def _client_without_credentials():
+    # Bypass __init__ (which builds a real bigquery.Client) and inject a mock.
+    client = BigqueryClient.__new__(BigqueryClient)
+    client.client = mock.MagicMock()
+    return client
+
+
+class TestUpdateAccessRetry(unittest.TestCase):
+    @mock.patch("google_cloud.bigquery_client.time.sleep", return_value=None)
+    def test_happy_path_updates_once_without_refetch(self, _sleep):
+        """A successful update must not retry or re-fetch (behaviour unchanged)."""
+        client = _client_without_credentials()
+        source_dataset = _make_dataset()
+        view = _make_view()
+
+        client._update_access(source_dataset, view)
+
+        self.assertEqual(client.client.update_dataset.call_count, 1)
+        self.assertEqual(client.client.get_dataset.call_count, 0)
+        _sleep.assert_not_called()
+
+    @mock.patch("google_cloud.bigquery_client.time.sleep", return_value=None)
+    def test_retries_on_precondition_failed_then_succeeds(self, _sleep):
+        """On a 412 the dataset is re-fetched and the update retried; a
+        concurrently-added access entry on the fresh dataset is preserved."""
+        client = _client_without_credentials()
+        source_dataset = _make_dataset()
+        view = _make_view()
+
+        # A concurrent writer already added an unrelated access entry to the
+        # dataset by the time we re-fetch it.
+        concurrent_entry = mock.MagicMock()
+        concurrent_entry.entity_type = "user"
+        refetched = _make_dataset(access_entries=[concurrent_entry])
+        client.client.get_dataset.return_value = refetched
+
+        # First update hits the ETag conflict, the retry succeeds.
+        client.client.update_dataset.side_effect = [PreconditionFailed("412"), None]
+
+        client._update_access(source_dataset, view)
+
+        self.assertEqual(client.client.update_dataset.call_count, 2)
+        client.client.get_dataset.assert_called_once_with("src-project.src_dataset")
+        # The concurrent entry survived and our view was appended on top of it.
+        self.assertIn(concurrent_entry, refetched.access_entries)
+        self.assertEqual(len(refetched.access_entries), 2)
+
+    @mock.patch("google_cloud.bigquery_client.time.sleep", return_value=None)
+    def test_reraises_after_persistent_precondition_failed(self, _sleep):
+        """A persistent 412 must still fail loudly after the last attempt."""
+        client = _client_without_credentials()
+        view = _make_view()
+        client.client.get_dataset.return_value = _make_dataset()
+        client.client.update_dataset.side_effect = PreconditionFailed("412")
+
+        with self.assertRaises(PreconditionFailed):
+            client._update_access(_make_dataset(), view)
+
+        # 5 attempts total, re-fetching before each of the 4 retries.
+        self.assertEqual(client.client.update_dataset.call_count, 5)
+        self.assertEqual(client.client.get_dataset.call_count, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds defensive handling for an unhandled `google.api_core.exceptions.PreconditionFailed`
(HTTP 412) observed in production. No change to the component's behaviour on inputs that
already worked.

## Root cause
`PreconditionFailed` (HTTP 412) raised from `self.client.update_dataset(source_dataset, ["access_entries"])`
in `src/google_cloud/bigquery_client.py` (`BigqueryClient._update_access`, was line 50).
`update_dataset` sends the dataset's ETag as an `If-Match` header, so when the source
dataset's access entries are modified concurrently (e.g. another view-writer granting
access to the same shared source dataset) between the `get_dataset` fetch and the update,
the API returns 412. It surfaced as an opaque internal error (exit 2). Classified as
**transient** (an optimistic-concurrency race); 1 occurrence in the alert window.

## Fix
Wrapped the access-entry update in a bounded exponential-backoff retry (5 attempts, base
2s, capped at 30s). On a 412 it **re-fetches the dataset** to get a fresh ETag and
**re-merges** the view access entry — using the existing append-if-missing logic — so any
concurrently-added access entries are preserved (no lost update). The retry **re-raises
after the last attempt**, so a persistent conflict still fails loudly. The original
merge+update logic is unchanged, extracted verbatim into `_grant_view_access` and invoked
once on the happy path.

## Behaviour impact: none — defensive-only
- Happy path unchanged: the first attempt runs the exact prior logic and returns on
  success; no outputs, transforms, schema, or config semantics touched.
- The job still fails on a genuine failure — the retry re-raises after the last attempt.
  Nothing is swallowed into a success; a successful retry genuinely completes the intended
  access grant.
- Narrow catch: only `PreconditionFailed` (412) is retried; unrelated errors propagate.
- Existing tests pass unchanged (no assertions modified or deleted), and a new regression
  test covers the retry, the concurrent-entry preservation, and the re-raise.

## Evidence
Datadog monitor: https://app.datadoghq.eu/monitors/97152903
Logs query: `(status:(critical OR emergency) service:job-queue-runner -env:(dev-* OR *testing*) (@component:kds-team.app-bigquery-byodb-view-writer OR @extra.component:kds-team.app-bigquery-byodb-view-writer))`

## Tests
Existing suite green, unchanged (4 passed) via the repo's toolchain
(`python -m unittest discover`). Added `tests/test_bigquery_client.py` with a regression
test for the handled path. `flake8` clean on `src`.